### PR TITLE
Open with preview.app if Kaleidoscope is not installed

### DIFF
--- a/SnapshotDiffs/ORTestsSuiteModels.m
+++ b/SnapshotDiffs/ORTestsSuiteModels.m
@@ -8,6 +8,7 @@
 
 #import "ORTestsSuiteModels.h"
 #import "NSFileManager+RecursiveFind.h"
+#import "ORKaleidoscopeController.h"
 
 @implementation ORTestSuite
 
@@ -147,8 +148,11 @@
 - (void)launch
 {
     NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath: @"/usr/local/bin/ksdiff"];
-
+    if ([ORKaleidoscopeController isInstalled]) {
+        [task setLaunchPath: @"/usr/local/bin/ksdiff"];
+    }else{
+        [task setLaunchPath: @"/usr/bin/open"];
+    }
     NSArray *arguments = @[ self.beforePath, self.afterPath];
     [task setArguments: arguments];
     [task launch];


### PR DESCRIPTION
Hi,

I just tried the plugin today and wanted to see the diff bigger. And since I don't have Kaleidoscope installed, I was back to preview.

I used to use preview before to inspect the diff, so I found the fallback interesting to have in the plugin.

As an alternative/addition, I also thought of possibility to zoom in the plugin diff.
