### PR TITLE
Add Xcode 6.2 UUID

### DIFF
--- a/SnapshotDiffs/SnapshotDiffs-Info.plist
+++ b/SnapshotDiffs/SnapshotDiffs-Info.plist
@@ -30,6 +30,7 @@
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>ORSnapshotDiffs</string>


### PR DESCRIPTION
This adds the UUID required for this plugin to load on Xcode 6.2.  UUID tested on Version 6.2 (6C131e) which is the App Store release version.