### PR TITLE
Adds Xcode 7 GM UUID

### DIFF
--- a/SnapshotDiffs/SnapshotDiffs-Info.plist
+++ b/SnapshotDiffs/SnapshotDiffs-Info.plist
@@ -34,7 +34,8 @@
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
-        <string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>ORSnapshotDiffs</string>


### PR DESCRIPTION
2015-09-09 had the release of Xcode 7 GM.

Based off of a PR I saw on XVim (https://github.com/endoze/XVim/commit/1186400ec9a5a81f8a67eb371190d046b88e15ae), I wanted the same change myself in Snapshots!  If Snapshots was specifically not going to be supported in Xcode 7 with the new UI Testing, my apologies - but I figured I'd pass this along in case anyone else got the GM and wanted to still use Snapshots).