### PR TITLE
Add UUID of Xcode Version 7.1 (7B91b)

### DIFF
--- a/SnapshotDiffs/SnapshotDiffs-Info.plist
+++ b/SnapshotDiffs/SnapshotDiffs-Info.plist
@@ -40,6 +40,7 @@
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
+		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>ORSnapshotDiffs</string>


### PR DESCRIPTION
This PR adds the missing UUID for Xcode 7.1, so we're able to use Snapshots again. :+1: 

