### PR TITLE
Remove all percentage encoding instead of only spaces

### DIFF
--- a/SnapshotDiffs/ORTestsSuiteModels.m
+++ b/SnapshotDiffs/ORTestsSuiteModels.m
@@ -193,7 +193,7 @@
 
     NSString *originalReference = [[NSFileManager defaultManager] or_findFileWithNamePrefix:name inFolder:folder];
     originalReference = [originalReference stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-    originalReference  = [originalReference stringByReplacingOccurrencesOfString:@"%20" withString:@" "];
+    originalReference = [originalReference stringByRemovingPercentEncoding];
     NSURL *originalFileURL = [NSURL fileURLWithPath:originalReference];
 
     if (![[NSFileManager defaultManager] removeItemAtURL:originalFileURL error:&error]) {


### PR DESCRIPTION
Swapping did not work in the case the url contained url encoded characters other than spaces. Instead of replacing url encoded spaces this PR removes all url encoding from the original reference url.