### PR TITLE
Add option to show inline diff and add new parsing syntax

### DIFF
--- a/SnapshotDiffs/ORLogReader.m
+++ b/SnapshotDiffs/ORLogReader.m
@@ -97,14 +97,19 @@
             }
         }
 
-        if ([line rangeOfString:@"successfully recorded"].location != NSNotFound) {
+        BOOL recordedReferenceImage = [line rangeOfString:@"Reference image save at"].location != NSNotFound ||
+                                      [line rangeOfString:@"successfully recorded"].location != NSNotFound;
+
+        if (recordedReferenceImage) {
             ORSnapshotCreationReference *snapshot = [ORSnapshotCreationReference referenceFromString:line];
 
             if (snapshot) {
                 ORTestCase *testCase = self.latestTestSuite.latestTestCase;
-                NSString *path = [[NSFileManager defaultManager] or_findFileWithNamePrefix:snapshot.name inFolder:self.latestTestSuite.name];
-                path = [path stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-                snapshot.path = [path stringByReplacingOccurrencesOfString:@"%20" withString:@" "];
+                if (nil == snapshot.path) {
+                    NSString *path = [[NSFileManager defaultManager] or_findFileWithNamePrefix:snapshot.name inFolder:self.latestTestSuite.name];
+                    path = [path stringByReplacingOccurrencesOfString:@"file://" withString:@""];
+                    snapshot.path = [path stringByRemovingPercentEncoding];
+                }
 
                 if (![self.mutableSnapshotCreations containsObject:snapshot]) {
                     [self.mutableSnapshotCreations addObject:snapshot];

--- a/SnapshotDiffs/ORPopoverController.m
+++ b/SnapshotDiffs/ORPopoverController.m
@@ -15,6 +15,8 @@
 
 @import Quartz;
 
+static NSUInteger const ORPreviewModeIndexCompare = 0;
+
 @interface ORPopoverController ()
 
 @property (strong) IBOutlet NSView *mainView;
@@ -36,6 +38,7 @@
 @property (nonatomic, strong) CATransition *masterDetailTransition;
 
 @property (nonatomic, strong) ORPopoverTableDataSource *tableDataSource;
+@property (weak) IBOutlet NSSegmentedControl *previewModeSegmentedControl;
 
 @property (nonatomic, weak) ORKaleidoscopeCommand *currentCommand;
 @property (strong) IBOutlet NSView *actionButtonsContainerView;
@@ -92,26 +95,42 @@
         
         self.detailSlidingView.frontImage = [[NSImage alloc] initWithContentsOfFile:[command beforePath]];
         self.detailSlidingView.backImage = [[NSImage alloc] initWithContentsOfFile:[command afterPath]];
-        
+        self.plainImagePreviewView.image = [[NSImage alloc] initWithContentsOfFile:[command diffPath]];
+
         self.detailSlidingView.frontMessage = @"Reference";
         self.detailSlidingView.backMessage = @"Recorded";
         
         self.detailTestDescription.stringValue = [command testCase].name;
         self.currentCommand = command;
         self.actionButtonsContainerView.hidden = NO;
+        self.previewModeSegmentedControl.hidden = NO;
+        [self updatePreviewModeWithIndex:self.previewModeSegmentedControl.selectedSegment];
     }
     
     if ([command isKindOfClass:ORSnapshotCreationReference.class]) {
         self.detailSlidingView.hidden = YES;
         self.plainImagePreviewView.hidden = NO;
+        self.previewModeSegmentedControl.hidden = YES;
         
-        self.plainImagePreviewView.image = [[NSImage alloc] initWithContentsOfFile:[command path]];
+        self.plainImagePreviewView.image = [[NSImage alloc] initWithContentsOfFile:(NSString *)[command path]];
         self.detailTestDescription.stringValue = [command testCase].name;
         self.actionButtonsContainerView.hidden = YES;
     }
 }
 
-- (IBAction)tappedCurrentDiff:(id)sender
+- (void)updatePreviewModeWithIndex:(NSUInteger)index
+{
+    BOOL compare = index == ORPreviewModeIndexCompare;
+    self.plainImagePreviewView.hidden = compare;
+    self.detailSlidingView.hidden = !compare;
+}
+
+- (IBAction)tappedPreviewMode:(NSSegmentedControl *)sender
+{
+    [self updatePreviewModeWithIndex:sender.selectedSegment];
+}
+
+- (IBAction)tappedOpenInKaleidoscope:(NSButtonCell *)sender
 {
     [self.currentCommand launch];
 }

--- a/SnapshotDiffs/ORPopoverController.xib
+++ b/SnapshotDiffs/ORPopoverController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ORPopoverController">
@@ -14,6 +14,7 @@
                 <outlet property="failingTestsTitle" destination="2au-A8-Rb4" id="gGL-Ps-eOz"/>
                 <outlet property="mainView" destination="8IX-oz-5Bw" id="qs8-7p-Axt"/>
                 <outlet property="plainImagePreviewView" destination="auu-Gh-2MY" id="yDf-1f-F1n"/>
+                <outlet property="previewModeSegmentedControl" destination="g39-dM-CLo" id="i5d-hA-8VL"/>
                 <outlet property="testTableView" destination="Wxm-sI-xiw" id="NKz-Sz-eYC"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -42,6 +43,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="166" viewBased="YES" id="Wxm-sI-xiw">
+                                        <rect key="frame" x="0.0" y="0.0" width="255" height="0.0"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <size key="intercellSpacing" width="0.0" height="2"/>
                                         <color key="backgroundColor" red="0.9490196704864502" green="0.9490196704864502" blue="0.9490196704864502" alpha="1" colorSpace="deviceRGB"/>
@@ -152,16 +154,16 @@
                     <rect key="frame" x="255" y="0.0" width="320" height="480"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="auu-Gh-2MY">
-                            <rect key="frame" x="23" y="57" width="277" height="400"/>
+                            <rect key="frame" x="20" y="57" width="280" height="380"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="qPf-nF-UtB"/>
                         </imageView>
                         <customView id="vTy-JQ-RFh" customClass="ORSlidingImageView">
-                            <rect key="frame" x="20" y="57" width="280" height="400"/>
+                            <rect key="frame" x="20" y="47" width="280" height="400"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         </customView>
                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" id="Ds5-1M-2kH">
-                            <rect key="frame" x="21" y="0.0" width="123" height="42"/>
+                            <rect key="frame" x="21" y="2" width="123" height="42"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Multiline Label this should be a mult line kinda bag" id="qi6-tp-gR4">
                                 <font key="font" metaFont="smallSystem"/>
@@ -170,13 +172,13 @@
                             </textFieldCell>
                         </textField>
                         <customView id="IvA-Qd-tzk">
-                            <rect key="frame" x="160" y="-13" width="160" height="56"/>
+                            <rect key="frame" x="142" y="5" width="160" height="42"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" id="ZvJ-HO-BrE">
-                                    <rect key="frame" x="2" y="19" width="95" height="17"/>
+                                    <rect key="frame" x="4" y="21" width="93" height="17"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="inline" title="Open in Finder" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="zls-0c-O8K">
+                                    <buttonCell key="cell" type="inline" title="Finder" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="zls-0c-O8K">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystemBold"/>
                                     </buttonCell>
@@ -185,7 +187,7 @@
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" id="HrI-oX-IPW">
-                                    <rect key="frame" x="107" y="38" width="45" height="17"/>
+                                    <rect key="frame" x="99" y="21" width="57" height="17"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <buttonCell key="cell" type="inline" title="Swap" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="0yk-Nu-8zg">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -195,21 +197,10 @@
                                         <action selector="swapImages:" target="-2" id="KcI-eO-w94"/>
                                     </connections>
                                 </button>
-                                <button verticalHuggingPriority="750" id="UPJ-HU-AwR">
-                                    <rect key="frame" x="107" y="19" width="45" height="17"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="inline" title="Diff" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="jhf-mI-7w3">
-                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                        <font key="font" metaFont="smallSystemBold"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <action selector="tappedCurrentDiff:" target="-2" id="bxv-R3-G07"/>
-                                    </connections>
-                                </button>
                                 <button verticalHuggingPriority="750" id="h1s-gG-NEw">
-                                    <rect key="frame" x="2" y="38" width="104" height="17"/>
+                                    <rect key="frame" x="99" y="3" width="57" height="17"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    <buttonCell key="cell" type="inline" title="Open in Preview" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="Fow-U1-mDx">
+                                    <buttonCell key="cell" type="inline" title="Preview" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="Fow-U1-mDx">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="smallSystemBold"/>
                                     </buttonCell>
@@ -217,8 +208,33 @@
                                         <action selector="openInPreview:" target="-2" id="bND-6s-WrD"/>
                                     </connections>
                                 </button>
+                                <button verticalHuggingPriority="750" id="r13-Eh-9Nz">
+                                    <rect key="frame" x="4" y="3" width="93" height="17"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <buttonCell key="cell" type="inline" title="Kaleidoscope" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="YHo-MZ-xuY">
+                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="smallSystemBold"/>
+                                        <connections>
+                                            <action selector="tappedOpenInKaleidoscope:" target="-2" id="lAW-MU-cUv"/>
+                                        </connections>
+                                    </buttonCell>
+                                </button>
                             </subviews>
                         </customView>
+                        <segmentedControl verticalHuggingPriority="750" id="g39-dM-CLo">
+                            <rect key="frame" x="97" y="447" width="125" height="24"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="mQS-Ir-nPt">
+                                <font key="font" metaFont="system"/>
+                                <segments>
+                                    <segment label="Compare" selected="YES"/>
+                                    <segment label="Diff" tag="1"/>
+                                </segments>
+                            </segmentedCell>
+                            <connections>
+                                <action selector="tappedPreviewMode:" target="-2" id="Ri8-OS-eE7"/>
+                            </connections>
+                        </segmentedControl>
                     </subviews>
                 </customView>
             </subviews>

--- a/SnapshotDiffs/ORTestsSuiteModels.h
+++ b/SnapshotDiffs/ORTestsSuiteModels.h
@@ -49,6 +49,7 @@
 @property (nonatomic, assign) BOOL fails;
 @property (nonatomic, copy) NSString *beforePath;
 @property (nonatomic, copy) NSString *afterPath;
+@property (nonatomic, copy) NSString *diffPath;
 @property (nonatomic, copy) NSString *fullCommand;
 @property (nonatomic, weak) ORTestCase *testCase;
 @property (nonatomic, copy) NSString *projectLocation;

--- a/SnapshotDiffs/ORTestsSuiteModels.m
+++ b/SnapshotDiffs/ORTestsSuiteModels.m
@@ -145,9 +145,19 @@
         obj.fullCommand = command;
         obj.beforePath = components[1];
         obj.afterPath = components[3];
+        obj.diffPath = [self diffPathWithBeforePath:obj.beforePath];
         return obj;
     }
     return nil;
+}
+
++ (NSString *)diffPathWithBeforePath:(NSString *)beforePath
+{
+    if (![beforePath containsString:@"reference"]) {
+        return nil;
+    }
+
+    return [beforePath stringByReplacingOccurrencesOfString:@"reference" withString:@"diff"];
 }
 
 - (NSURL *)beforeURL
@@ -240,6 +250,19 @@
         obj.name = [endComponents.firstObject componentsSeparatedByString:@"snapshot "].lastObject;
         return obj;
     }
+
+    // 2016-05-14 20:05:09.209 CaffeineTracker[46257:11199502] Reference image save at: /Users/Silvan/Developer/CaffeineTracker/CaffeineTrackerTests/ReferenceImages_64/CaffeineTrackerTests.WeekdayIntakeViewTests/testConfiguration@2x.png
+
+    NSArray *alternateComponents = [line componentsSeparatedByString:@"Reference image save at: "];
+    NSURL *alternatePath = [NSURL URLWithString:alternateComponents.lastObject];
+
+    if (nil != alternateComponents) {
+        ORSnapshotCreationReference *obj = [[self alloc] init];
+        obj.name = [alternatePath.lastPathComponent stringByDeletingPathExtension];
+        obj.path = alternatePath.path;
+        return obj;
+    }
+
     return nil;
 }
 

--- a/Testing/SnapshotsTests/SnapshotsTests.xcodeproj/project.pbxproj
+++ b/Testing/SnapshotsTests/SnapshotsTests.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		608CFC6F1C90D0FC00B9056C /* QuickNewSnapshot.log in Resources */ = {isa = PBXBuildFile; fileRef = 608CFC6E1C90D0FC00B9056C /* QuickNewSnapshot.log */; };
 		608CFC701C90D1DB00B9056C /* QuickNewSnapshot.log in Resources */ = {isa = PBXBuildFile; fileRef = 608CFC6E1C90D0FC00B9056C /* QuickNewSnapshot.log */; };
 		608CFC721C90D38D00B9056C /* QuickJustNewSnapshot.log in Resources */ = {isa = PBXBuildFile; fileRef = 608CFC711C90D38D00B9056C /* QuickJustNewSnapshot.log */; };
+		AFF2E9491CE7AF4E0027177C /* ReferenceImageSave.log in Resources */ = {isa = PBXBuildFile; fileRef = AFF2E9481CE7AF4E0027177C /* ReferenceImageSave.log */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		60071FD41AE7FD0F000ED7DB /* MultiSnapshotsPerTest.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MultiSnapshotsPerTest.log; sourceTree = "<group>"; };
 		608CFC6E1C90D0FC00B9056C /* QuickNewSnapshot.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QuickNewSnapshot.log; sourceTree = "<group>"; };
 		608CFC711C90D38D00B9056C /* QuickJustNewSnapshot.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QuickJustNewSnapshot.log; sourceTree = "<group>"; };
+		AFF2E9481CE7AF4E0027177C /* ReferenceImageSave.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ReferenceImageSave.log; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 				60071FD41AE7FD0F000ED7DB /* MultiSnapshotsPerTest.log */,
 				608CFC6E1C90D0FC00B9056C /* QuickNewSnapshot.log */,
 				608CFC711C90D38D00B9056C /* QuickJustNewSnapshot.log */,
+				AFF2E9481CE7AF4E0027177C /* ReferenceImageSave.log */,
 			);
 			name = "Example Logs";
 			sourceTree = "<group>";
@@ -253,6 +256,7 @@
 				60071FA11AE7FC08000ED7DB /* Images.xcassets in Resources */,
 				60071FD51AE7FD0F000ED7DB /* MultiSnapshotsPerTest.log in Resources */,
 				608CFC721C90D38D00B9056C /* QuickJustNewSnapshot.log in Resources */,
+				AFF2E9491CE7AF4E0027177C /* ReferenceImageSave.log in Resources */,
 				60071FA41AE7FC08000ED7DB /* MainMenu.xib in Resources */,
 				608CFC701C90D1DB00B9056C /* QuickNewSnapshot.log in Resources */,
 			);

--- a/Testing/SnapshotsTests/SnapshotsTests/ReferenceImageSave.log
+++ b/Testing/SnapshotsTests/SnapshotsTests/ReferenceImageSave.log
@@ -1,0 +1,18 @@
+2016-05-14 21:09:53.866 CaffeineTracker[55104:11323548] [Crashlytics] Version 3.7.0 (102)
+21:09:54.106 CaffeineTracker[55104:11323702] _XCT_testBundleReadyWithProtocolVersion:minimumVersion: reply received
+21:09:54.126 CaffeineTracker[55104:11323681] _IDE_startExecutingTestPlanWithProtocolVersion:16
+Test Suite 'Selected tests' started at 2016-05-14 21:09:54.131
+Test Suite 'WeekdayIntakeViewTests' started at 2016-05-14 21:09:54.132
+Test Case '-[CaffeineTrackerTests.WeekdayIntakeViewTests testConfiguration]' started.
+2016-05-14 21:09:54.143 CaffeineTracker[55104:11323548] Reference image save at: /Users/Silvan/Developer/CaffeineTracker/CaffeineTrackerTests/ReferenceImages_64/CaffeineTrackerTests.WeekdayIntakeViewTests/testConfiguration@2x.png
+
+
+Test session log:
+/Users/Silvan/Library/Developer/Xcode/DerivedData/CaffeineTracker-bjnrptgprhvssgalespvskznqvbb/Logs/Test/A2334604-7B20-4F7A-BD2B-7282291918D5/Session-2016-05-14_21:09:47-eoMWFk.log
+
+/Users/Silvan/Developer/CaffeineTracker/Pods/FBSnapshotTestCase/FBSnapshotTestCase/SwiftSupport.swift:13: error: -[CaffeineTrackerTests.WeekdayIntakeViewTests testConfiguration] : failed - Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!
+Test Case '-[CaffeineTrackerTests.WeekdayIntakeViewTests testConfiguration]' failed (0.013 seconds).
+Test Suite 'WeekdayIntakeViewTests' failed at 2016-05-14 21:09:54.146.
+Executed 1 test, with 1 failure (0 unexpected) in 0.013 (0.014) seconds
+Test Suite 'Selected tests' failed at 2016-05-14 21:09:54.147.
+Executed 1 test, with 1 failure (0 unexpected) in 0.013 (0.015) seconds

--- a/Testing/SnapshotsTests/SnapshotsTestsTests/SnapshotsTestsTests.m
+++ b/Testing/SnapshotsTests/SnapshotsTestsTests/SnapshotsTestsTests.m
@@ -52,5 +52,15 @@
     XCTAssert(reader.hasNewSnapshots, @"Expected to have snapshots");
 }
 
+- (void)testReferenceImageSaveNewRecording {
+    ORLogReader *reader = [[ORLogReader alloc] init];
+
+    [self runLog:@"ReferenceImageSave"];
+
+    XCTAssertTrue(reader.hasNewSnapshots, @"Expected to have snapshots");
+    XCTAssertEqual(reader.uniqueDiffCommands.count, 0lu, @"Expected 0 unique diff commands");
+    XCTAssertEqual(reader.ksdiffCommands.count, 0lu, @"Expected 0 diff commands");
+}
+
 
 @end


### PR DESCRIPTION
As this is my favorite Xcode plugin I wanted to give it a try and contribute back and add the inline displaying of diffs of failed comparisons. I added a segmented control above the slider view with the option to show the diff provided by `FBSnapshotTestCase`. This control is only shown for failed comparisons, not for newly recorded ones. I reuse the image view for newly recorded snapshots to display the diff. 

To avoid ambiguity I renamed the "Diff" option to "Kaleidoscope" as "Open in Kaleidoscope" was a bit long and in turn also removed the "Open in" prefix from the other options, but am unsure about that change.

This PR also adds parsing of the (changed?) console logs for newly added snapshots prefixed with "Reference image save at".

Some screenshots:
<img width="601" alt="screenshot 2016-05-14 21 49 06" src="https://cloud.githubusercontent.com/assets/4603353/15270411/8e0667e2-1a1f-11e6-8f2d-8365832de540.png">

<img width="554" alt="screenshot 2016-05-14 21 49 45" src="https://cloud.githubusercontent.com/assets/4603353/15270413/95eda448-1a1f-11e6-9274-a6711018a1d3.png">